### PR TITLE
Add SupportFTStrategy example

### DIFF
--- a/examples/friend_backtest.py
+++ b/examples/friend_backtest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from src import DataStore, DataPortal, Engine
+from src.strategies import FriendStrategy
+from src.analysis import analyze
+
+
+def main() -> None:
+    store = DataStore(Path("market_data"))
+    portal = DataPortal(store, ["SPY"])
+    strategy = FriendStrategy("SPY")
+    engine = Engine(portal, strategy, starting_cash=10_000.0)
+    # Limit to one year of data to keep the example fast
+    results = engine.run(start=pd.Timestamp("2015-01-01"), end=pd.Timestamp("2016-01-01"))
+    report = analyze(results)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/support_ft_backtest.py
+++ b/examples/support_ft_backtest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+
+from src import DataStore, DataPortal, Engine, analyze
+from src.strategies import SupportFTStrategy
+
+
+def main() -> None:
+    store = DataStore(Path("market_data"))
+    portal = DataPortal(store, ["SPY"])
+    # trade 5%% of portfolio each trade
+    strategy = SupportFTStrategy("SPY", trade_pct=0.05)
+    engine = Engine(portal, strategy, starting_cash=10_000.0)
+    results = engine.run(start=pd.Timestamp("2015-01-01"), end=pd.Timestamp("2016-01-01"))
+    report = analyze(results)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,12 @@
 from .data import DataStore, DataPortal, DataSeries, download_history
 from .engine import Engine
 from .strategy import Strategy
-from .strategies import MovingAverageCrossStrategy, MACDStrategy
+from .strategies import (
+    MovingAverageCrossStrategy,
+    MACDStrategy,
+    FriendStrategy,
+    SupportFTStrategy,
+)
 from .analysis import analyze
 
 __all__ = [
@@ -13,5 +18,7 @@ __all__ = [
     "Strategy",
     "MovingAverageCrossStrategy",
     "MACDStrategy",
+    "FriendStrategy",
+    "SupportFTStrategy",
     "analyze",
 ]

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,8 +1,12 @@
 """Collection of trading strategies."""
 from .moving_average import MovingAverageCrossStrategy
 from .macd import MACDStrategy
+from .friend_strategy import FriendStrategy
+from .support_ft_strategy import SupportFTStrategy
 
 __all__ = [
     "MovingAverageCrossStrategy",
     "MACDStrategy",
+    "FriendStrategy",
+    "SupportFTStrategy",
 ]

--- a/src/strategies/friend_strategy.py
+++ b/src/strategies/friend_strategy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Dict, List
+import pandas as pd
+
+from ..strategy import Strategy
+
+
+class FriendStrategy(Strategy):
+    """Simplified version of the example freqtrade strategy."""
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+        self.history = pd.DataFrame()
+        self.in_position = False
+
+    # ------------------------------------------------------------------
+    def _rsi(self, series: pd.Series, period: int) -> float:
+        if len(series) < period + 1:
+            return float('nan')
+        delta = series.diff().dropna()
+        gain = delta.where(delta > 0, 0.0)
+        loss = -delta.where(delta < 0, 0.0)
+        avg_gain = gain.rolling(period).mean().iloc[-1]
+        avg_loss = loss.rolling(period).mean().iloc[-1]
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def _ema(self, series: pd.Series, period: int) -> float:
+        if len(series) < period:
+            return series.iloc[-1]
+        return series.ewm(span=period, adjust=False).mean().iloc[-1]
+
+    def _sma(self, series: pd.Series, period: int) -> float:
+        if len(series) < period:
+            return series.mean()
+        return series.rolling(period).mean().iloc[-1]
+
+    def _cti(self, series: pd.Series, length: int = 20) -> float:
+        if len(series) < length + 1:
+            return 0.0
+        return (series.iloc[-1] - series.iloc[-length]) / series.iloc[-length]
+
+    def _ewo(self, df: pd.DataFrame, ema1: int = 50, ema2: int = 200) -> float:
+        close = df['Close']
+        low = df['Low']
+        if len(close) < ema2:
+            return 0.0
+        ema_fast = close.ewm(span=ema1, adjust=False).mean().iloc[-1]
+        ema_slow = close.ewm(span=ema2, adjust=False).mean().iloc[-1]
+        return (ema_fast - ema_slow) / low.iloc[-1] * 100
+
+    # ------------------------------------------------------------------
+    def on_bar(
+        self,
+        engine: "Engine",
+        timestamp: pd.Timestamp,
+        data: Dict[str, pd.Series],
+    ) -> None:
+        row = data[self.symbol]
+        self.history = pd.concat([self.history, row.to_frame().T])
+        df = self.history
+
+        close = df['Close']
+        rsi = self._rsi(close, 14)
+        rsi_fast = self._rsi(close, 4)
+        rsi_slow = self._rsi(close, 20)
+        ema8 = self._ema(close, 8)
+        ema16 = self._ema(close, 16)
+        sma15 = self._sma(close, 15)
+        cti = self._cti(close, 20)
+        ewo = self._ewo(df)
+
+        buy_ewo = (
+            rsi_fast < 50
+            and row['Close'] < ema8 * 0.956
+            and ewo > -1.238
+            and row['Close'] < ema16 * 0.986
+            and rsi < 30
+        )
+
+        buy_1 = (
+            rsi_slow < self._rsi(close[:-1], 20)
+            and rsi_fast < 63
+            and rsi > 16
+            and row['Close'] < sma15 * 0.932
+            and cti < -0.8
+        )
+
+        if not self.in_position and (buy_ewo or buy_1):
+            engine.buy(self.symbol, 1)
+            self.in_position = True
+        elif self.in_position and rsi_fast > 70:
+            engine.sell(self.symbol, 1)
+            self.in_position = False
+
+
+__all__ = ["FriendStrategy"]

--- a/src/strategies/support_ft_strategy.py
+++ b/src/strategies/support_ft_strategy.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import Dict
+import pandas as pd
+import numpy as np
+
+from ..strategy import Strategy
+
+
+class SupportFTStrategy(Strategy):
+    """Simplified version of the complex freqtrade strategy.
+
+    Parameters
+    ----------
+    symbol: str
+        Trading symbol.
+    trade_qty: int, optional
+        Number of shares to trade per action when `trade_pct` is None.
+    trade_pct: float | None, optional
+        If provided, portion of portfolio value to use for each trade.
+    """
+
+    def __init__(self, symbol: str, trade_qty: int = 10, trade_pct: float | None = None) -> None:
+        self.symbol = symbol
+        self.trade_qty = trade_qty
+        self.trade_pct = trade_pct
+        self.history = pd.DataFrame()
+        self.in_position = False
+
+    # ------------------------------------------------------------------
+    def _rsi(self, series: pd.Series, period: int) -> float:
+        if len(series) < period + 1:
+            return float("nan")
+        delta = series.diff().dropna()
+        gain = delta.where(delta > 0, 0.0)
+        loss = -delta.where(delta < 0, 0.0)
+        avg_gain = gain.rolling(period).mean().iloc[-1]
+        avg_loss = loss.rolling(period).mean().iloc[-1]
+        if avg_loss == 0:
+            return 100.0
+        rs = avg_gain / avg_loss
+        return 100 - (100 / (1 + rs))
+
+    def _ema(self, series: pd.Series, period: int) -> float:
+        if len(series) < period:
+            return series.iloc[-1]
+        return series.ewm(span=period, adjust=False).mean().iloc[-1]
+
+    def _sma(self, series: pd.Series, period: int) -> float:
+        if len(series) < period:
+            return series.mean()
+        return series.rolling(period).mean().iloc[-1]
+
+    def _cti(self, series: pd.Series, length: int = 20) -> float:
+        if len(series) < length + 1:
+            return 0.0
+        prev = series.iloc[-length]
+        if prev == 0:
+            return 0.0
+        return (series.iloc[-1] - prev) / prev
+
+    def _ewo(self, df: pd.DataFrame, ema1: int = 50, ema2: int = 200) -> float:
+        close = df["Close"]
+        low = df["Low"]
+        if len(close) < ema2:
+            return 0.0
+        ema_fast = close.ewm(span=ema1, adjust=False).mean().iloc[-1]
+        ema_slow = close.ewm(span=ema2, adjust=False).mean().iloc[-1]
+        return (ema_fast - ema_slow) / low.iloc[-1] * 100
+
+    def _fisher(self, rsi: float) -> float:
+        x = 0.1 * (rsi - 50)
+        return (np.exp(2 * x) - 1) / (np.exp(2 * x) + 1)
+
+    def _trade_qty(self, engine: "Engine", price: float) -> int:
+        """Determine quantity based on settings."""
+        if self.trade_pct is not None:
+            portfolio_val = engine.portfolio.value(engine._current_bar)
+            qty = int((portfolio_val * self.trade_pct) / price)
+            return max(qty, 1)
+        return self.trade_qty
+
+    # ------------------------------------------------------------------
+    def on_bar(
+        self,
+        engine: "Engine",
+        timestamp: pd.Timestamp,
+        data: Dict[str, pd.Series],
+    ) -> None:
+        row = data[self.symbol]
+        self.history = pd.concat([self.history, row.to_frame().T])
+        df = self.history
+
+        close = df["Close"]
+        rsi = self._rsi(close, 14)
+        rsi_fast = self._rsi(close, 4)
+        ema16 = self._ema(close, 16)
+        ema26 = self._ema(close, 26)
+        ema12 = self._ema(close, 12)
+        cti = self._cti(close)
+        ewo = self._ewo(df)
+
+        # simplified Bollinger lower band
+        if len(close) >= 20:
+            mid = close.rolling(20).mean().iloc[-1]
+            std = close.rolling(20).std().iloc[-1]
+            bb_lower = mid - 2 * std
+        else:
+            mid = close.mean()
+            std = close.std(ddof=0)
+            bb_lower = mid - 2 * std
+
+        buy_dip = (
+            row["Close"] < ema16 * 0.982
+            and ewo < -10.0
+            and cti < -0.9
+            and rsi < 35
+        )
+
+        buy_uptrend = (
+            ema26 > ema12
+            and (ema26 - ema12) > row["Open"] * 0.025
+            and row["Close"] < bb_lower
+        )
+
+        if not self.in_position and (buy_dip or buy_uptrend):
+            qty = self._trade_qty(engine, row["Close"])
+            engine.buy(self.symbol, qty)
+            self.in_position = True
+        elif self.in_position:
+            fisher = self._fisher(rsi)
+            if fisher > 0.4 or rsi_fast > 70:
+                qty = self._trade_qty(engine, row["Close"])
+                owned = engine.portfolio.positions.get(self.symbol, 0)
+                qty = min(qty, owned)
+                engine.sell(self.symbol, qty)
+                if engine.portfolio.positions.get(self.symbol, 0) == 0:
+                    self.in_position = False
+
+
+__all__ = ["SupportFTStrategy"]
+
+


### PR DESCRIPTION
## Summary
- implement SupportFTStrategy with variable trade size or portfolio percentage
- expose new strategy via package exports
- add example backtest using SupportFTStrategy

## Testing
- `pytest -q`
- `PYTHONPATH=. python examples/support_ft_backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_683fe72bcf508326924ee6396345676a