### PR TITLE
Fix frontend symbol fetch proxy

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,6 +10,8 @@ export default defineConfig({
       '/indicator': 'http://localhost:8000',
       '/backtest': 'http://localhost:8000',
       '/strategies': 'http://localhost:8000',
+      '/symbols': 'http://localhost:8000',
+      '/fetch': 'http://localhost:8000',
     },
   },
 })

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from src import DataStore
+import src.server as server
+
+
+def _write_sample_csv(root: Path, symbol: str, closes: List[float]):
+    dates = pd.date_range("2020-01-01", periods=len(closes), freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": closes,
+            "High": closes,
+            "Low": closes,
+            "Close": closes,
+            "Adj Close": closes,
+            "Volume": 1000,
+        },
+        index=dates,
+    )
+    df.to_csv(root / f"{symbol}.csv", date_format="%Y-%m-%d")
+
+
+def test_symbols_endpoint(tmp_path, monkeypatch):
+    _write_sample_csv(tmp_path, "AAA", [1, 2])
+    _write_sample_csv(tmp_path, "BBB", [3, 4])
+
+    ds = DataStore(tmp_path)
+    monkeypatch.setattr(server, "store", ds)
+    monkeypatch.setattr(server, "DATA_ROOT", Path(tmp_path))
+    server._PORTALS.clear()
+
+    client = TestClient(server.app)
+    resp = client.get("/symbols")
+    assert resp.status_code == 200
+    assert resp.json() == {"symbols": ["AAA", "BBB"]}


### PR DESCRIPTION
## Summary
- proxy `/symbols` and `/fetch` in frontend dev server
- add an API test for the `/symbols` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427b8014408326bc2230e219afe60a