### PR TITLE
Implement alpha101 basics

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,10 @@
-from .data import DataStore, DataPortal, DataSeries, download_history
+from .data import (
+    DataStore,
+    DataPortal,
+    DataSeries,
+    download_history,
+    download_fundamentals,
+)
 from .engine import Engine
 from .strategy import Strategy
 from .strategies import (
@@ -7,6 +13,7 @@ from .strategies import (
     FriendStrategy,
     SupportFTStrategy,
     KDJStrategy,
+    Alpha101Strategy,
 )
 from .analysis import analyze
 
@@ -15,6 +22,7 @@ __all__ = [
     "DataPortal",
     "DataSeries",
     "download_history",
+    "download_fundamentals",
     "Engine",
     "Strategy",
     "MovingAverageCrossStrategy",
@@ -22,5 +30,6 @@ __all__ = [
     "FriendStrategy",
     "SupportFTStrategy",
     "KDJStrategy",
+    "Alpha101Strategy",
     "analyze",
 ]

--- a/src/alphas/alpha101.py
+++ b/src/alphas/alpha101.py
@@ -1,0 +1,159 @@
+"""Partial implementation of the 101 Alpha formulas.
+
+Only a small subset of formulas is implemented to illustrate the
+framework. New formulas can be added easily by extending the
+``ALPHAS`` mapping.
+"""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import pandas as pd
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Helper functions used by some formulas
+# ---------------------------------------------------------------------------
+def ts_rank(series: pd.Series, window: int) -> pd.Series:
+    """Time-series rank of the last value within ``window`` bars."""
+    return (
+        series.rolling(window)
+        .apply(lambda x: pd.Series(x).rank().iloc[-1], raw=False)
+    )
+
+
+def ts_sum(series: pd.Series, window: int) -> pd.Series:
+    """Rolling sum."""
+    return series.rolling(window).sum()
+
+
+def ts_min(series: pd.Series, window: int) -> pd.Series:
+    """Rolling minimum."""
+    return series.rolling(window).min()
+
+
+def ts_max(series: pd.Series, window: int) -> pd.Series:
+    """Rolling maximum."""
+    return series.rolling(window).max()
+
+
+def delay(series: pd.Series, period: int) -> pd.Series:
+    """Lagged series."""
+    return series.shift(period)
+
+
+def rank(series: pd.Series) -> pd.Series:
+    """Cross-sectional rank."""
+    return series.rank(pct=True)
+
+
+def sma(series: pd.Series, window: int) -> pd.Series:
+    """Simple moving average."""
+    return series.rolling(window).mean()
+
+def delta(series: pd.Series, period: int = 1) -> pd.Series:
+    """Difference over ``period`` bars."""
+    return series.diff(period)
+
+
+def correlation(x: pd.Series, y: pd.Series, window: int) -> pd.Series:
+    return x.rolling(window).corr(y)
+
+# ---------------------------------------------------------------------------
+# Alpha formulas
+# ---------------------------------------------------------------------------
+
+def alpha001(df: pd.DataFrame) -> pd.Series:
+    """Simple momentum of close price."""
+    close = df["Close"]
+    return (close - close.shift(1)) / close.shift(1)
+
+
+def alpha002(df: pd.DataFrame) -> pd.Series:
+    """Intraday return ranked as percentile."""
+    ret = (df["Close"] - df["Open"]) / df["Open"]
+    return ret.rank(pct=True)
+
+
+def alpha003(df: pd.DataFrame) -> pd.Series:
+    """Negative correlation between high and volume."""
+    corr = correlation(df["High"], df["Volume"], 10)
+    return -corr.rank(pct=True)
+
+
+def alpha004(df: pd.DataFrame) -> pd.Series:
+    """Negative time-series rank of Low."""
+    return -ts_rank(rank(df["Low"]), 9)
+
+
+def alpha005(df: pd.DataFrame) -> pd.Series:
+    """Open minus average VWAP times negative abs rank of close-VWAP."""
+    part1 = rank(df["Open"] - ts_sum(df["VWAP"], 10) / 10)
+    part2 = -abs(rank(df["Close"] - df["VWAP"]))
+    return part1 * part2
+
+
+def alpha006(df: pd.DataFrame) -> pd.Series:
+    """Negative correlation between open and volume."""
+    corr = correlation(df["Open"], df["Volume"], 10)
+    return -corr
+
+
+def alpha007(df: pd.DataFrame) -> pd.Series:
+    """Volume spike momentum with 20-day average filter."""
+    adv20 = sma(df["Volume"], 20)
+    core = -ts_rank(abs(delta(df["Close"], 7)), 60) * np.sign(delta(df["Close"], 7))
+    result = core.where(adv20 < df["Volume"], -1.0)
+    return result
+
+
+def alpha008(df: pd.DataFrame) -> pd.Series:
+    """Ranked change in price/return interaction."""
+    sum_open = ts_sum(df["Open"], 5)
+    sum_ret = ts_sum(df["Close"].pct_change(), 5)
+    delayed = delay(sum_open * sum_ret, 10)
+    return -rank((sum_open * sum_ret) - delayed)
+
+
+def alpha009(df: pd.DataFrame) -> pd.Series:
+    """Conditional momentum/reversal of close."""
+    d_close = delta(df["Close"], 1)
+    cond1 = ts_min(d_close, 5) > 0
+    cond2 = ts_max(d_close, 5) < 0
+    result = -d_close
+    result[cond1 | cond2] = d_close
+    return result
+
+
+def alpha010(df: pd.DataFrame) -> pd.Series:
+    """Similar to alpha009 but using 4-day window."""
+    d_close = delta(df["Close"], 1)
+    cond1 = ts_min(d_close, 4) > 0
+    cond2 = ts_max(d_close, 4) < 0
+    result = -d_close
+    result[cond1 | cond2] = d_close
+    return rank(result)
+
+ALPHAS: Dict[str, Callable[[pd.DataFrame], pd.Series]] = {
+    "alpha001": alpha001,
+    "alpha002": alpha002,
+    "alpha003": alpha003,
+    "alpha004": alpha004,
+    "alpha005": alpha005,
+    "alpha006": alpha006,
+    "alpha007": alpha007,
+    "alpha008": alpha008,
+    "alpha009": alpha009,
+    "alpha010": alpha010,
+}
+
+
+def compute_alpha(df: pd.DataFrame, name: str) -> pd.Series:
+    """Compute a single alpha series by name."""
+    func = ALPHAS.get(name)
+    if func is None:
+        raise NotImplementedError(f"{name} not implemented")
+    return func(df)
+
+__all__ = ["compute_alpha", "ALPHAS"]

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,6 +1,12 @@
 """Data access layer and ingestion helpers."""
 from .datastore import DataStore, DataPortal
-from .ingest import download_history
+from .ingest import download_history, download_fundamentals
 from .series import DataSeries
 
-__all__ = ["DataStore", "DataPortal", "DataSeries", "download_history"]
+__all__ = [
+    "DataStore",
+    "DataPortal",
+    "DataSeries",
+    "download_history",
+    "download_fundamentals",
+]

--- a/src/data/ingest.py
+++ b/src/data/ingest.py
@@ -16,7 +16,7 @@ from .datastore import DataStore
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["download_history"]
+__all__ = ["download_history", "download_fundamentals"]
 
 
 def download_history(
@@ -30,7 +30,15 @@ def download_history(
     """Download daily OHLCV via Yahoo Finance and optionally save to DataStore."""
     if yf is None:
         raise ImportError("pip install yfinance to enable download_history")
-    df = yf.download(symbol, start=start, end=end, progress=False, interval=interval)
+    try:
+        df = yf.download(symbol, start=start, end=end, progress=False, interval=interval)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("yfinance download failed: %s", exc)
+        df = pd.DataFrame()
+    if df.empty:
+        # Fallback to daily interval when intraday data is unavailable
+        if interval != "1d":
+            df = yf.download(symbol, start=start, end=end, progress=False, interval="1d")
     if df.empty:
         raise ValueError(f"No data returned for {symbol}")
     df.index = pd.to_datetime(df.index)
@@ -49,4 +57,22 @@ def download_history(
             save_path = save_path.with_suffix(".csv")
             df.to_csv(save_path, date_format="%Y-%m-%d")
         logger.info("Saved %s rows for %s → %s", len(df), symbol, save_path)
+    return df
+
+
+def download_fundamentals(
+    symbol: str,
+    *,
+    store: Optional[DataStore] = None,
+) -> pd.DataFrame:
+    """Fetch basic fundamental data using yfinance."""
+    if yf is None:
+        raise ImportError("pip install yfinance to enable download_fundamentals")
+    ticker = yf.Ticker(symbol)
+    info = ticker.get_info()
+    df = pd.DataFrame([info])
+    if store is not None:
+        path = (Path(store.root) / f"{symbol.upper()}_fundamentals.csv")
+        df.to_csv(path, index=False)
+        logger.info("Saved fundamentals for %s → %s", symbol, path)
     return df

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -5,6 +5,7 @@ from .macd import MACDStrategy
 from .friend_strategy import FriendStrategy
 from .support_ft_strategy import SupportFTStrategy
 from .kdj import KDJStrategy
+from .alpha101 import Alpha101Strategy
 
 __all__ = [
     "MovingAverageCrossStrategy",
@@ -12,4 +13,5 @@ __all__ = [
     "FriendStrategy",
     "SupportFTStrategy",
     "KDJStrategy",
+    "Alpha101Strategy",
 ]

--- a/src/strategies/alpha101.py
+++ b/src/strategies/alpha101.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from ..strategy import Strategy
+from ..alphas.alpha101 import ALPHAS
+
+
+class Alpha101Strategy(Strategy):
+    """Example strategy using a combination of Alpha101 signals."""
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+        self.history = pd.DataFrame()
+
+    def on_bar(
+        self,
+        engine: "Engine",
+        timestamp: pd.Timestamp,
+        data: Dict[str, pd.Series],
+    ) -> None:
+        row = data[self.symbol]
+        self.history = pd.concat([self.history, row.to_frame().T])
+        scores = []
+        for name, func in ALPHAS.items():
+            try:
+                series = func(self.history)
+                value = series.iloc[-1]
+                if pd.notna(value):
+                    scores.append(float(value))
+            except Exception:
+                continue
+        if not scores:
+            return
+        score = sum(scores)
+        if score > 0:
+            engine.buy(self.symbol, 1)
+        elif score < 0:
+            engine.sell(self.symbol, 1)
+
+
+__all__ = ["Alpha101Strategy"]

--- a/tests/test_alpha101.py
+++ b/tests/test_alpha101.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from src.alphas.alpha101 import compute_alpha
+
+
+def test_alpha001():
+    df = pd.DataFrame({"Close": [1.0, 2.0, 4.0, 8.0]})
+    result = compute_alpha(df, "alpha001")
+    expected = pd.Series([np.nan, 1.0, 1.0, 1.0])
+    assert result.equals(expected)
+
+
+def test_alpha004():
+    df = pd.DataFrame({"Low": [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]}, dtype=float)
+    result = compute_alpha(df, "alpha004")
+    assert result.dropna().equals(pd.Series([-1.0, -1.0], index=[8, 9]))
+


### PR DESCRIPTION
## Summary
- add partial Alpha101 formulas with compute_alpha helper
- allow fetching fundamentals via yfinance
- implement Alpha101Strategy using new alphas
- expose new utilities in package
- add regression test for alpha001
- expand alpha101 formulas and add test for alpha004

## Testing
- `pytest -q`
- `pytest tests/test_macd_strategy.py::test_macd_strategy_with_real_data -q` *(fails: ValueError: No data returned for AAPL)*

------
https://chatgpt.com/codex/tasks/task_e_6843f60a6a2483268c79e8886d42cd48