### PR TITLE
Fix multi-symbol allocation and redesign symbol selection

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -31,6 +31,22 @@
   margin-top: 1rem;
 }
 
+.symbol-select {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.symbol-select select {
+  min-width: 120px;
+}
+
+.symbol-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .report {
   text-align: left;
   background: #f5f5f5;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,8 @@ export default function App() {
   const [fetchSym, setFetchSym] = useState('');
   const [fetchStart, setFetchStart] = useState('2000-01-01');
   const [fetchEnd, setFetchEnd] = useState('');
+  const [availSel, setAvailSel] = useState([]);
+  const [chosenSel, setChosenSel] = useState([]);
 
   // Load symbols and strategies on mount
   useEffect(() => {
@@ -84,6 +86,16 @@ export default function App() {
     // reload symbol list
     const syms = await fetch('/symbols').then((r) => r.json());
     setSymbols(syms.symbols);
+  };
+
+  const addSelected = () => {
+    setSelectedSyms([...selectedSyms, ...availSel]);
+    setAvailSel([]);
+  };
+
+  const removeSelected = () => {
+    setSelectedSyms(selectedSyms.filter((s) => !chosenSel.includes(s)));
+    setChosenSel([]);
   };
 
   const priceData = {
@@ -153,19 +165,42 @@ export default function App() {
       {tab === 'backtest' && (
         <div>
           <div className="controls">
-            <select
-              multiple
-              value={selectedSyms}
-              onChange={(e) =>
-                setSelectedSyms(Array.from(e.target.selectedOptions, (o) => o.value))
-              }
-            >
-              {symbols.map((s) => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
-            </select>
+            <div className="symbol-select">
+              <select
+                multiple
+                size={5}
+                value={availSel}
+                onChange={(e) =>
+                  setAvailSel(Array.from(e.target.selectedOptions, (o) => o.value))
+                }
+              >
+                {symbols
+                  .filter((s) => !selectedSyms.includes(s))
+                  .map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+              </select>
+              <div className="symbol-buttons">
+                <button onClick={addSelected}>&gt;</button>
+                <button onClick={removeSelected}>&lt;</button>
+              </div>
+              <select
+                multiple
+                size={5}
+                value={chosenSel}
+                onChange={(e) =>
+                  setChosenSel(Array.from(e.target.selectedOptions, (o) => o.value))
+                }
+              >
+                {selectedSyms.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
             <select value={strategy} onChange={(e) => setStrategy(e.target.value)}>
               {strategies.map((s) => (
                 <option key={s} value={s}>

--- a/src/strategies/alpha_weight.py
+++ b/src/strategies/alpha_weight.py
@@ -48,9 +48,9 @@ class AlphaWeightStrategy(Strategy):
             return
         weights = {sym: ranks[sym] / total for sym in scores}
 
-        portfolio_value = engine.portfolio.value(data)
         for sym, weight in weights.items():
             price = data[sym]["Close"]
+            portfolio_value = engine.portfolio.value(data)
             target_qty = int((portfolio_value * weight) / price)
             owned = engine.portfolio.positions.get(sym, 0)
             diff = target_qty - owned


### PR DESCRIPTION
## Summary
- avoid overspending when allocating across multiple symbols
- add dedicated UI to pick multiple symbols
- style symbol selection widget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684539af21e883269bf276e9008e9a19