### PR TITLE
Implement pullback strategy

### DIFF
--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -7,6 +7,7 @@ from .support_ft_strategy import SupportFTStrategy
 from .kdj import KDJStrategy
 from .alpha101 import Alpha101Strategy
 from .alpha_weight import AlphaWeightStrategy
+from .pullback_strategy import PullbackStrategy
 
 __all__ = [
     "MovingAverageCrossStrategy",
@@ -16,4 +17,5 @@ __all__ = [
     "KDJStrategy",
     "Alpha101Strategy",
     "AlphaWeightStrategy",
+    "PullbackStrategy",
 ]

--- a/src/strategies/pullback_strategy.py
+++ b/src/strategies/pullback_strategy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from ..strategy import Strategy
+
+
+class PullbackStrategy(Strategy):
+    """Buy after a drop from the recent high and sell after a rally from the
+    recent low.
+
+    Parameters
+    ----------
+    symbol: str
+        Trading symbol.
+    buy_threshold: float, optional
+        Fractional drop from the recent high that triggers a buy. ``0.03`` means
+        buy if price falls more than 3% from the highest seen price.
+    sell_threshold: float, optional
+        Fractional rise from the recent low that triggers a sell. ``0.04`` means
+        sell if price rises more than 4% from the lowest seen price.
+    trade_qty: int, optional
+        Number of shares to buy each time the condition is met.
+    sell_pct: float, optional
+        Portion of the current position to sell when the sell condition is met.
+    """
+
+    def __init__(
+        self,
+        symbol: str,
+        *,
+        buy_threshold: float = 0.03,
+        sell_threshold: float = 0.04,
+        trade_qty: int = 1000,
+        sell_pct: float = 0.07,
+    ) -> None:
+        self.symbol = symbol
+        self.buy_threshold = buy_threshold
+        self.sell_threshold = sell_threshold
+        self.trade_qty = trade_qty
+        self.sell_pct = sell_pct
+        self.recent_low: float | None = None
+        self.recent_high: float | None = None
+
+    # ------------------------------------------------------------------
+    def on_bar(
+        self,
+        engine: "Engine",
+        timestamp: pd.Timestamp,
+        data: Dict[str, pd.Series],
+    ) -> None:
+        price = data[self.symbol]["Close"]
+
+        if self.recent_high is None or price > self.recent_high:
+            self.recent_high = float(price)
+        if self.recent_low is None or price < self.recent_low:
+            self.recent_low = float(price)
+
+        # Buy if price dropped sufficiently from recent high
+        if (
+            self.recent_high is not None
+            and price <= self.recent_high * (1 - self.buy_threshold)
+        ):
+            engine.buy(self.symbol, self.trade_qty)
+            self.recent_high = float(price)
+
+        # Sell a portion if price rallied sufficiently from recent low
+        if (
+            self.recent_low is not None
+            and price >= self.recent_low * (1 + self.sell_threshold)
+        ):
+            owned = engine.portfolio.positions.get(self.symbol, 0)
+            qty = int(owned * self.sell_pct)
+            if qty > 0:
+                engine.sell(self.symbol, qty)
+            self.recent_low = float(price)
+
+
+__all__ = ["PullbackStrategy"]

--- a/tests/test_pullback_strategy.py
+++ b/tests/test_pullback_strategy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from src import DataStore, DataPortal, Engine
+from src.strategies import PullbackStrategy
+
+
+def _write_sample_csv(root: Path, symbol: str, closes: List[float]):
+    dates = pd.date_range("2020-01-01", periods=len(closes), freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": closes,
+            "High": closes,
+            "Low": closes,
+            "Close": closes,
+            "Adj Close": closes,
+            "Volume": 1000,
+        },
+        index=dates,
+    )
+    df.to_csv(root / f"{symbol}.csv", date_format="%Y-%m-%d")
+
+
+def test_pullback_strategy(tmp_path: Path):
+    closes = [100, 102, 98, 97, 104, 98, 110]
+    _write_sample_csv(tmp_path, "XXX", closes)
+    store = DataStore(tmp_path)
+    portal = DataPortal(store, ["XXX"])
+    strat = PullbackStrategy(
+        "XXX",
+        buy_threshold=0.03,
+        sell_threshold=0.04,
+        trade_qty=10,
+        sell_pct=0.5,
+    )
+    engine = Engine(portal, strat, starting_cash=10000.0)
+    results = engine.run()
+
+    assert len(engine.trades) == 4
+    assert engine.portfolio.positions["XXX"] == 8
+    final_value = results["value"].iloc[-1]
+    assert final_value > 10000.0


### PR DESCRIPTION
## Summary
- implement `PullbackStrategy` for drop/rally based trades
- expose new strategy in strategies package
- cover strategy with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68525d42288c8326a6813558667d25fa